### PR TITLE
Fix tasks creation

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -31,6 +31,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:description)
+    params.require(:task).permit(:title, :description)
   end
 end


### PR DESCRIPTION
This PR fixes the ability to add new tasks by adding the `:title` parameter to `task_params` method